### PR TITLE
feat(config): move husky install to prepare step

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,8 @@
     "lint:staged": "lint-staged --concurrent 1",
     "format": "yarn prettier:fix && yarn lint:fix",
     "build": "yarn clean && tsc",
-    "prepare": "yarn build",
+    "prepare": "yarn build && npx husky install",
     "test": "jest",
-    "postinstall": "husky install",
     "semantic-release": "semantic-release"
   },
   "files": [


### PR DESCRIPTION
As a `postinstall` script, it was trying to install when people referenced this project as a dependency. We only need this to be installed if you're developing this project.

![image](https://github.com/douglascayers/promise-coalesce/assets/4142577/78957af8-c446-421d-93a7-fd45f3e215d1)
